### PR TITLE
Setup CI for cargo tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - run: cargo test --verbose


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow running `cargo test`
- trigger the job on pushes to `main` and on every PR

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68486de8fba883288da1339d994ddc9f