### PR TITLE
Allow multiple <text> tags

### DIFF
--- a/src/ast2pdft/mod.rs
+++ b/src/ast2pdft/mod.rs
@@ -87,12 +87,16 @@ fn content_node_from_ast(
     obj_num: usize,
     gen_num: usize,
 ) -> crate::pdf_tree::ContentNode {
-    let text_node = text_node_from_ast(&ast_content.child_text);
+    let text_nodes = ast_content
+        .child_texts
+        .iter()
+        .map(|t| text_node_from_ast(t))
+        .collect();
 
     crate::pdf_tree::ContentNode {
         obj_num: obj_num,
         gen_num: gen_num,
-        content: text_node,
+        contents: text_nodes,
     }
 }
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -14,7 +14,7 @@ Page: PageNode = {
 };
 
 Content: ContentNode = {
-    "<content>" <text:Text> "</content>" => ContentNode { child_text: text },
+    "<content>" <texts:Text+> "</content>" => ContentNode { child_texts: texts },
 };
 
 Text: TextNode = {

--- a/src/parser/constants.rs
+++ b/src/parser/constants.rs
@@ -11,7 +11,7 @@ pub struct PageNode {
 
 #[derive(Debug, PartialEq)]
 pub struct ContentNode {
-    pub child_text: TextNode,
+    pub child_texts: Vec<TextNode>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -31,7 +31,7 @@ three</text></content></page></pdf>";
 
         match result {
             Ok(pdf_node) => {
-                assert_eq!(pdf_node.child_page.child_content.child_text.child_string, "one   two\nthree".to_string());
+                assert_eq!(pdf_node.child_page.child_content.child_texts[0].child_string, "one   two\nthree".to_string());
             }
             Err(e) => panic!("Expected Ok, got Err: {}", e),
         }
@@ -42,5 +42,14 @@ three</text></content></page></pdf>";
         let input = "<pdf><page></pdf>";
         let result = parse(input);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_multiple_texts() {
+        let input = "<pdf><page><content><text>one</text><text>two</text></content></page></pdf>";
+        let result = parse(input).unwrap();
+        assert_eq!(result.child_page.child_content.child_texts.len(), 2);
+        assert_eq!(result.child_page.child_content.child_texts[0].child_string, "one");
+        assert_eq!(result.child_page.child_content.child_texts[1].child_string, "two");
     }
 }

--- a/src/pdf_tree/content_node.rs
+++ b/src/pdf_tree/content_node.rs
@@ -3,7 +3,7 @@ use super::text_node::TextNode;
 pub struct ContentNode {
     pub obj_num: usize,
     pub gen_num: usize,
-    pub content: TextNode,
+    pub contents: Vec<TextNode>,
 }
 
 impl ContentNode {
@@ -16,14 +16,15 @@ impl ContentNode {
     }
 
     fn to_obj(&self) -> String {
-        let text = self.content.to_obj();
+        let texts: Vec<String> = self.contents.iter().map(|t| t.to_obj()).collect();
+        let joined = texts.join("\n");
 
         return format!(
             "{} {} obj\n<< /Length {}>>\nstream\n{}\nendstream\nendobj\n",
             self.obj_num,
             self.gen_num,
-            text.as_bytes().len(),
-            text
+            joined.as_bytes().len(),
+            joined
         );
     }
 }

--- a/src/pdf_tree/mod.rs
+++ b/src/pdf_tree/mod.rs
@@ -48,13 +48,13 @@ mod tests {
                             contents: ContentNode {
                                 obj_num: 4,
                                 gen_num: 0,
-                                content: TextNode {
+                                contents: vec![TextNode {
                                     font: "F1".to_string(),
                                     font_size: 24,
                                     x_pos: 100,
                                     y_pos: 700,
                                     text: "Hello World".to_string(),
-                                },
+                                }],
                             },
                         },
                     ],


### PR DESCRIPTION
## Summary
- support one or more `<text>` tags inside `<content>`
- expose the new `child_texts` vector in the AST
- join text objects when writing PDF streams
- add a regression test for multiple texts
- update example to show multiple text tags

## Testing
- `cargo test --quiet`
- `cargo build --quiet`
- `cargo run --quiet < examples/simple.pdfl`

------
https://chatgpt.com/codex/tasks/task_e_6848b34c628c83289cbd2c2e083fcb26