### PR TITLE
Add text positioning attributes

### DIFF
--- a/src/ast2pdft/mod.rs
+++ b/src/ast2pdft/mod.rs
@@ -101,13 +101,24 @@ fn content_node_from_ast(
 }
 
 fn text_node_from_ast(ast_text: &crate::parser::TextNode) -> crate::pdf_tree::TextNode {
-    return crate::pdf_tree::TextNode {
+    let x_pos = ast_text
+        .attributes
+        .get("pos_x")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(100);
+    let y_pos = ast_text
+        .attributes
+        .get("pos_y")
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(700);
+
+    crate::pdf_tree::TextNode {
         font: "F1".to_string(),
         font_size: 24,
-        x_pos: 100,
-        y_pos: 700,
+        x_pos,
+        y_pos,
         text: ast_text.child_string.clone(),
-    };
+    }
 }
 
 #[cfg(test)]
@@ -220,5 +231,15 @@ startxref
 973
 %%EOF");
 
-}
+    }
+
+    #[test]
+    fn test_text_position_attributes() {
+        let code = "<pdf><page><content><text pos_x=\"20\" pos_y=\"50\">a</text></content></page></pdf>";
+        let node = crate::parser::parse(code).unwrap();
+        let pdft = to_pdft(node);
+        let buffer = pdft.to_buffer();
+        let pdf_string = String::from_utf8(buffer).unwrap();
+        assert!(pdf_string.contains("20 50 Td"));
+    }
 }

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,4 +1,4 @@
-use crate::parser::{PdfNode, PageNode, ContentNode, TextNode};
+use crate::parser::{PdfNode, PageNode, ContentNode, TextNode, parse_attributes};
 
 grammar;
 
@@ -18,7 +18,8 @@ Content: ContentNode = {
 };
 
 Text: TextNode = {
-    "<text>" <s:r"[^<]*"> "</text>" => TextNode {
-        child_string: s.trim().to_string()
+    <open:r#"<text[^>]*>"#> <s:r"[^<]*"> "</text>" => TextNode {
+        child_string: s.trim().to_string(),
+        attributes: parse_attributes(open.trim_start_matches("<text").trim_end_matches('>')),
     },
 };

--- a/src/parser/constants.rs
+++ b/src/parser/constants.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 #[derive(Debug, PartialEq)]
 pub struct PdfNode {
     pub child_page: PageNode,
@@ -17,4 +19,5 @@ pub struct ContentNode {
 #[derive(Debug, PartialEq)]
 pub struct TextNode {
     pub child_string: String,
+    pub attributes: HashMap<String, String>,
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,6 +15,17 @@ pub fn parse(input: &str) -> Result<PdfNode, String> {
     }
 }
 
+pub fn parse_attributes(input: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for part in input.split_whitespace() {
+        if let Some((k, v)) = part.split_once('=') {
+            let v = v.trim_matches('"');
+            map.insert(k.to_string(), v.to_string());
+        }
+    }
+    map
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,5 +62,15 @@ three</text></content></page></pdf>";
         assert_eq!(result.child_page.child_content.child_texts.len(), 2);
         assert_eq!(result.child_page.child_content.child_texts[0].child_string, "one");
         assert_eq!(result.child_page.child_content.child_texts[1].child_string, "two");
+    }
+
+    #[test]
+    fn test_parse_text_with_attributes() {
+        let input = "<pdf><page><content><text pos_x=\"20\" pos_y=\"50\">hello</text></content></page></pdf>";
+        let result = parse(input).unwrap();
+        let text = &result.child_page.child_content.child_texts[0];
+        assert_eq!(text.child_string, "hello");
+        assert_eq!(text.attributes.get("pos_x"), Some(&"20".to_string()));
+        assert_eq!(text.attributes.get("pos_y"), Some(&"50".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
- allow attributes in `<text>` tag
- parse attributes into a map
- use `pos_x` and `pos_y` to position text
- add tests for new behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6848c32fa6ac832898aae98f25d3b3d3