### PR TITLE
Add page resources and font attribute

### DIFF
--- a/examples/text.pdf
+++ b/examples/text.pdf
@@ -12,48 +12,62 @@ endobj
 endobj
 3 0 obj
 << /Type /Page
-/Resources << /Font << /F1 4 0 R >> >>
-/Contents 5 0 R
+/Resources << /Font << /helvetica 6 0 R /times 5 0 R /Courier 4 0 R >> >>
+/Contents 7 0 R
 >>
 endobj
-4 0 obj
+6 0 obj
 << /Type /Font
 /Subtype /Type1
 /BaseFont /Helvetica
 >>
 endobj
 5 0 obj
-<< /Length 152>>
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Times-Roman
+>>
+endobj
+4 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Courier
+>>
+endobj
+7 0 obj
+<< /Length 167>>
 stream
 BT
-/F1 50 Tf
+/Courier 50 Tf
 225 700 Td
 (PDFL) Tj
 ET
 BT
-/F1 20 Tf
+/helvetica 20 Tf
 130 620 Td
 (The Markup Language to generate PDF) Tj
 ET
 BT
-/F1 10 Tf
+/times 10 Tf
 250 100 Td
 (@juneira - 2025) Tj
 ET
 endstream
 endobj
 xref
-0 5
+0 7
 0000000000 65535 f
 0000000010 00000 n
 0000000060 00000 n
 0000000118 00000 n
-0000000207 00000 n
-0000000366 00000 n
+0000000242 00000 n
+0000000436 00000 n
+0000000702 00000 n
+0000001036 00000 n
 trailer
-<< /Size 5
+<< /Size 7
 /Root 1 0 R
 >>
 startxref
-367
+1037
 %%EOF

--- a/examples/text.pdfl
+++ b/examples/text.pdfl
@@ -1,13 +1,18 @@
 <pdf>
   <page>
+    <resource>
+      <font key="Courier" base_font="Courier" />
+      <font key="times" base_font="Times-Roman" />
+      <font key="helvetica" base_font="Helvetica" />
+    </resource>
     <content>
-      <text pos_x="225" pos_y="700" font_size="50">
+      <text font="Courier" pos_x="225" pos_y="700" font_size="50">
         PDFL
       </text>
-      <text pos_x="130" pos_y="620" font_size="20">
+      <text font="helvetica" pos_x="130" pos_y="620" font_size="20">
         The Markup Language to generate PDF
       </text>
-      <text pos_x="250" pos_y="100" font_size="10">
+      <text font="times" pos_x="250" pos_y="100" font_size="10">
         @juneira - 2025
       </text>
     </content>

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,4 +1,4 @@
-use crate::parser::{PdfNode, PageNode, ContentNode, TextNode, parse_attributes};
+use crate::parser::{PdfNode, PageNode, ContentNode, TextNode, ResourceNode, FontNode, parse_attributes};
 
 grammar;
 
@@ -7,7 +7,8 @@ pub Pdf: PdfNode = {
 };
 
 Page: PageNode = {
-    "<page>" <content:Content> "</page>" <next:Page?> => PageNode {
+    "<page>" <resource:Resource?> <content:Content> "</page>" <next:Page?> => PageNode {
+        resources: resource,
         child_content: content,
         child_page: next.map(Box::new),
     },
@@ -15,6 +16,16 @@ Page: PageNode = {
 
 Content: ContentNode = {
     "<content>" <texts:Text+> "</content>" => ContentNode { child_texts: texts },
+};
+
+Resource: ResourceNode = {
+    "<resource>" <fonts:Font+> "</resource>" => ResourceNode { fonts: fonts },
+};
+
+Font: FontNode = {
+    <open:r#"<font[^>]*/>"#> => FontNode {
+        attributes: parse_attributes(open.trim_start_matches("<font").trim_end_matches("/>")),
+    },
 };
 
 Text: TextNode = {

--- a/src/parser/constants.rs
+++ b/src/parser/constants.rs
@@ -7,8 +7,19 @@ pub struct PdfNode {
 
 #[derive(Debug, PartialEq)]
 pub struct PageNode {
+    pub resources: Option<ResourceNode>,
     pub child_content: ContentNode,
     pub child_page: Option<Box<PageNode>>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ResourceNode {
+    pub fonts: Vec<FontNode>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct FontNode {
+    pub attributes: HashMap<String, String>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -34,9 +34,9 @@ mod tests {
     fn test_parse_simple_pdf() {
         let input = "        <pdf>
 
-        <page>     <content>
+        <page>     <resource><font key=\"f1\" /></resource> <content>
 
-<text>  one   two
+<text font=\"f1\">  one   two
 three</text></content></page></pdf>";
         let result = parse(input);
 
@@ -57,7 +57,7 @@ three</text></content></page></pdf>";
 
     #[test]
     fn test_parse_multiple_texts() {
-        let input = "<pdf><page><content><text>one</text><text>two</text></content></page></pdf>";
+        let input = "<pdf><page><resource><font key=\"f1\" /></resource><content><text font=\"f1\">one</text><text font=\"f1\">two</text></content></page></pdf>";
         let result = parse(input).unwrap();
         assert_eq!(result.child_page.child_content.child_texts.len(), 2);
         assert_eq!(result.child_page.child_content.child_texts[0].child_string, "one");
@@ -66,7 +66,7 @@ three</text></content></page></pdf>";
 
     #[test]
     fn test_parse_text_with_attributes() {
-        let input = "<pdf><page><content><text pos_x=\"20\" pos_y=\"50\">hello</text></content></page></pdf>";
+        let input = "<pdf><page><resource><font key=\"f1\" /></resource><content><text font=\"f1\" pos_x=\"20\" pos_y=\"50\">hello</text></content></page></pdf>";
         let result = parse(input).unwrap();
         let text = &result.child_page.child_content.child_texts[0];
         assert_eq!(text.child_string, "hello");


### PR DESCRIPTION
## Summary
- support `<resource>` in page for defining fonts
- require `font` attribute on `<text>` nodes
- use optional defaults for font subtype and base_font
- update AST structures, grammar, and conversion logic
- adjust tests for new syntax

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68495ff8fc388328bd0fda5cdd62a9db