### PR TITLE
Add color attribute for text tags

### DIFF
--- a/examples/text.pdf
+++ b/examples/text.pdf
@@ -12,8 +12,14 @@ endobj
 endobj
 3 0 obj
 << /Type /Page
-/Resources << /Font << /helvetica 6 0 R /times 5 0 R /Courier 4 0 R >> >>
+/Resources << /Font << /Courier 4 0 R /helvetica 6 0 R /times 5 0 R >> >>
 /Contents 7 0 R
+>>
+endobj
+4 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Courier
 >>
 endobj
 6 0 obj
@@ -28,27 +34,24 @@ endobj
 /BaseFont /Times-Roman
 >>
 endobj
-4 0 obj
-<< /Type /Font
-/Subtype /Type1
-/BaseFont /Courier
->>
-endobj
 7 0 obj
-<< /Length 167>>
+<< /Length 225>>
 stream
 BT
 /Courier 50 Tf
+1 0.2 0.2 rg
 225 700 Td
 (PDFL) Tj
 ET
 BT
 /helvetica 20 Tf
+0.41960785 0.41960785 0.41960785 rg
 130 620 Td
 (The Markup Language to generate PDF) Tj
 ET
 BT
 /times 10 Tf
+0 0 0 rg
 250 100 Td
 (@juneira - 2025) Tj
 ET
@@ -61,13 +64,13 @@ xref
 0000000060 00000 n
 0000000118 00000 n
 0000000242 00000 n
-0000000436 00000 n
-0000000702 00000 n
-0000001036 00000 n
+0000000434 00000 n
+0000000696 00000 n
+0000001030 00000 n
 trailer
 << /Size 7
 /Root 1 0 R
 >>
 startxref
-1037
+1031
 %%EOF

--- a/examples/text.pdfl
+++ b/examples/text.pdfl
@@ -6,10 +6,10 @@
       <font key="helvetica" base_font="Helvetica" />
     </resource>
     <content>
-      <text font="Courier" pos_x="225" pos_y="700" font_size="50">
+      <text font="Courier" pos_x="225" pos_y="700" font_size="50" color="#FF3333">
         PDFL
       </text>
-      <text font="helvetica" pos_x="130" pos_y="620" font_size="20">
+      <text font="helvetica" pos_x="130" pos_y="620" font_size="20" color="#6B6B6B">
         The Markup Language to generate PDF
       </text>
       <text font="times" pos_x="250" pos_y="100" font_size="10">

--- a/src/ast2pdft/mod.rs
+++ b/src/ast2pdft/mod.rs
@@ -162,12 +162,21 @@ fn text_node_from_ast(ast_text: &crate::parser::TextNode) -> crate::pdf_tree::Te
         .unwrap_or("F1".to_string())
         .to_string();
 
+    let color = ast_text
+        .attributes
+        .get("color")
+        .map(|v| v.trim_start_matches('#'))
+        .and_then(|v| u32::from_str_radix(v, 16).ok())
+        .map(|rgb| (((rgb >> 16) & 0xff) as u8, ((rgb >> 8) & 0xff) as u8, (rgb & 0xff) as u8))
+        .unwrap_or((0, 0, 0));
+
     crate::pdf_tree::TextNode {
         font,
         font_size,
         x_pos,
         y_pos,
         text: ast_text.child_string.clone(),
+        color,
     }
 }
 
@@ -236,10 +245,11 @@ endobj
 >>
 endobj
 5 0 obj
-<< /Length 81>>
+<< /Length 90>>
 stream
 BT
 /F1 24 Tf
+0 0 0 rg
 100 700 Td
 (texto    mais    longoooo
                     pdf) Tj
@@ -259,10 +269,11 @@ endobj
 >>
 endobj
 8 0 obj
-<< /Length 43>>
+<< /Length 52>>
 stream
 BT
 /F1 24 Tf
+0 0 0 rg
 100 700 Td
 (Outro texto) Tj
 ET
@@ -276,15 +287,15 @@ xref
 0000000124 00000 n
 0000000213 00000 n
 0000000372 00000 n
-0000000724 00000 n
-0000000813 00000 n
-0000000972 00000 n
+0000000733 00000 n
+0000000822 00000 n
+0000000981 00000 n
 trailer
 << /Size 8
 /Root 1 0 R
 >>
 startxref
-973
+982
 %%EOF");
 
     }

--- a/src/pdf_tree/mod.rs
+++ b/src/pdf_tree/mod.rs
@@ -54,6 +54,7 @@ mod tests {
                                     x_pos: 100,
                                     y_pos: 700,
                                     text: "Hello World".to_string(),
+                                    color: (0, 0, 0),
                                 }],
                             },
                         },
@@ -89,10 +90,11 @@ endobj
 >>
 endobj
 4 0 obj
-<< /Length 43>>
+<< /Length 52>>
 stream
 BT
 /F1 24 Tf
+0 0 0 rg
 100 700 Td
 (Hello World) Tj
 ET

--- a/src/pdf_tree/text_node.rs
+++ b/src/pdf_tree/text_node.rs
@@ -4,13 +4,17 @@ pub struct TextNode {
     pub x_pos: usize,
     pub y_pos: usize,
     pub text: String,
+    pub color: (u8, u8, u8),
 }
 
 impl TextNode {
     pub fn to_obj(&self) -> String {
+        let (r, g, b) = self.color;
+        let color_str = format!("{} {} {} rg", r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0);
+
         return format!(
-            "BT\n/{} {} Tf\n{} {} Td\n({}) Tj\nET",
-            self.font, self.font_size, self.x_pos, self.y_pos, self.text
+            "BT\n/{} {} Tf\n{}\n{} {} Td\n({}) Tj\nET",
+            self.font, self.font_size, color_str, self.x_pos, self.y_pos, self.text
         );
     }
 }


### PR DESCRIPTION
## Summary
- add `color` to `TextNode` representation and render it
- parse optional `color` attribute when converting AST to PDF tree
- update tests for new `color` support

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6849efde9a508328b9156c0337509fc0