### PR TITLE
Add image element parsing

### DIFF
--- a/src/ast2pdft/mod.rs
+++ b/src/ast2pdft/mod.rs
@@ -128,18 +128,22 @@ fn content_node_from_ast(
     let elements = ast_content
         .children
         .iter()
-        .map(|el| match el {
+        .filter_map(|el| match el {
             crate::parser::ContentElement::Text(t) => {
-                crate::pdf_tree::ContentItem::Text(text_node_from_ast(t))
+                Some(crate::pdf_tree::ContentItem::Text(text_node_from_ast(t)))
             }
             crate::parser::ContentElement::Rectangle(r) => {
-                crate::pdf_tree::ContentItem::Rectangle(rect_node_from_ast(r))
+                Some(crate::pdf_tree::ContentItem::Rectangle(rect_node_from_ast(r)))
             }
             crate::parser::ContentElement::Line(l) => {
-                crate::pdf_tree::ContentItem::Line(line_node_from_ast(l))
+                Some(crate::pdf_tree::ContentItem::Line(line_node_from_ast(l)))
             }
             crate::parser::ContentElement::Circle(c) => {
-                crate::pdf_tree::ContentItem::Circle(circle_node_from_ast(c))
+                Some(crate::pdf_tree::ContentItem::Circle(circle_node_from_ast(c)))
+            }
+            crate::parser::ContentElement::Image(_i) => {
+                // Image elements are not yet supported in PDF generation
+                None
             }
         })
         .collect();

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -1,4 +1,4 @@
-use crate::parser::{PdfNode, PageNode, ContentNode, ContentElement, TextNode, RectangleNode, LineNode, CircleNode, ResourceNode, FontNode, parse_attributes};
+use crate::parser::{PdfNode, PageNode, ContentNode, ContentElement, TextNode, RectangleNode, LineNode, CircleNode, ImageNode, ResourceNode, FontNode, parse_attributes};
 
 grammar;
 
@@ -33,6 +33,7 @@ Element: ContentElement = {
     <r:Rectangle> => ContentElement::Rectangle(r),
     <l:Line> => ContentElement::Line(l),
     <c:Circle> => ContentElement::Circle(c),
+    <i:Image> => ContentElement::Image(i),
 };
 
 Rectangle: RectangleNode = {
@@ -50,6 +51,12 @@ Line: LineNode = {
 Circle: CircleNode = {
     <open:r#"<circle[^>]*/>"#> => CircleNode {
         attributes: parse_attributes(open.trim_start_matches("<circle").trim_end_matches("/>")),
+    },
+};
+
+Image: ImageNode = {
+    <open:r#"<image[^>]*/>"#> => ImageNode {
+        attributes: parse_attributes(open.trim_start_matches("<image").trim_end_matches("/>")),
     },
 };
 

--- a/src/parser/constants.rs
+++ b/src/parser/constants.rs
@@ -28,6 +28,7 @@ pub enum ContentElement {
     Rectangle(RectangleNode),
     Line(LineNode),
     Circle(CircleNode),
+    Image(ImageNode),
 }
 
 #[derive(Debug, PartialEq)]
@@ -53,5 +54,10 @@ pub struct LineNode {
 
 #[derive(Debug, PartialEq)]
 pub struct CircleNode {
+    pub attributes: HashMap<String, String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ImageNode {
     pub attributes: HashMap<String, String>,
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -130,4 +130,20 @@ three</text></content></page></pdf>";
             _ => panic!("Expected circle"),
         }
     }
+
+    #[test]
+    fn test_parse_image() {
+        let input = "<pdf><page><content><image src=\"img.png\" pos_x=\"1\" pos_y=\"2\" width=\"3\" height=\"4\" /></content></page></pdf>";
+        let result = parse(input).unwrap();
+        match &result.child_page.child_content.children[0] {
+            ContentElement::Image(img) => {
+                assert_eq!(img.attributes.get("src"), Some(&"img.png".to_string()));
+                assert_eq!(img.attributes.get("pos_x"), Some(&"1".to_string()));
+                assert_eq!(img.attributes.get("pos_y"), Some(&"2".to_string()));
+                assert_eq!(img.attributes.get("width"), Some(&"3".to_string()));
+                assert_eq!(img.attributes.get("height"), Some(&"4".to_string()));
+            }
+            _ => panic!("Expected image"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `ImageNode` and integrate it into `ContentElement`
- parse `<image />` tags in the grammar
- skip image elements when converting to PDF
- test parsing of `<image />`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68580b5792a08328ae76c4150adc6c15