### PR TITLE
Add ImageNode struct and ContentItem variant

### DIFF
--- a/src/pdf_tree/content_node.rs
+++ b/src/pdf_tree/content_node.rs
@@ -2,12 +2,14 @@ use super::text_node::TextNode;
 use super::rectangle_node::RectangleNode;
 use super::line_node::LineNode;
 use super::circle_node::CircleNode;
+use super::image_node::ImageNode;
 
 pub enum ContentItem {
     Text(TextNode),
     Rectangle(RectangleNode),
     Line(LineNode),
     Circle(CircleNode),
+    Image(ImageNode),
 }
 
 impl ContentItem {
@@ -17,6 +19,7 @@ impl ContentItem {
             ContentItem::Rectangle(r) => r.to_obj(),
             ContentItem::Line(l) => l.to_obj(),
             ContentItem::Circle(c) => c.to_obj(),
+            ContentItem::Image(i) => i.to_obj(),
         }
     }
 }

--- a/src/pdf_tree/image_node.rs
+++ b/src/pdf_tree/image_node.rs
@@ -1,0 +1,21 @@
+pub struct ImageNode {
+    pub attributes: std::collections::HashMap<String, String>,
+}
+
+impl ImageNode {
+    pub fn to_obj(&self) -> String {
+        "% TODO: implement image drawing".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_to_obj_placeholder() {
+        let image = ImageNode { attributes: HashMap::new() };
+        assert_eq!(image.to_obj(), "% TODO: implement image drawing");
+    }
+}

--- a/src/pdf_tree/mod.rs
+++ b/src/pdf_tree/mod.rs
@@ -8,6 +8,7 @@ mod text_node;
 mod rectangle_node;
 mod line_node;
 mod circle_node;
+mod image_node;
 
 pub use pdf_node::PdfNode;
 pub use font_node::FontNode;
@@ -19,6 +20,7 @@ pub use text_node::TextNode;
 pub use rectangle_node::RectangleNode;
 pub use line_node::LineNode;
 pub use circle_node::CircleNode;
+pub use image_node::ImageNode;
 pub use content_node::ContentItem;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- support image nodes in the PDF tree
- export the new type
- handle `Image` in `ContentItem` and provide placeholder output
- test the new `ImageNode` module

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68580cc881fc832899785a448e1840cf