### PR TITLE
Support external fonts

### DIFF
--- a/docs/examples/font.pdfl
+++ b/docs/examples/font.pdfl
@@ -1,0 +1,9 @@
+<pdf>
+  <page>
+    <content>
+      <text font="matrix.ttf" pos_x="50" pos_y="700" font_size="24">
+        Hello Matrix
+      </text>
+    </content>
+  </page>
+</pdf>

--- a/src/ast2pdft/catalog_converter.rs
+++ b/src/ast2pdft/catalog_converter.rs
@@ -7,9 +7,14 @@ impl CatalogConverter {
         Self
     }
 
-    pub fn convert(&self, ast_pdf: crate::parser::PdfNode, images: &[String]) -> (crate::pdf_tree::CatalogNode, usize) {
+    pub fn convert(
+        &self,
+        ast_pdf: crate::parser::PdfNode,
+        images: &[String],
+        fonts: &[String],
+    ) -> (crate::pdf_tree::CatalogNode, usize) {
         let pages_converter = PagesConverter::new();
-        let (pages_node, total_obj) = pages_converter.convert(ast_pdf.child_page, images);
+        let (pages_node, total_obj) = pages_converter.convert(ast_pdf.child_page, images, fonts);
 
         let catalog = crate::pdf_tree::CatalogNode {
             obj_num: 1,

--- a/src/ast2pdft/mod.rs
+++ b/src/ast2pdft/mod.rs
@@ -1,18 +1,22 @@
-mod pdf_converter_main;
+mod attribute_parser;
 mod catalog_converter;
-mod pages_converter;
-mod page_converter;
-mod font_converter;
-mod image_converter;
 mod content_converter;
 mod element_converter;
-mod attribute_parser;
+mod font_converter;
+mod image_converter;
+mod page_converter;
+mod pages_converter;
+mod pdf_converter_main;
 
 pub use pdf_converter_main::PdfConverter;
 
-pub fn to_pdft(pdf_node: crate::parser::PdfNode, images: &[String]) -> crate::pdf_tree::PdfNode {
+pub fn to_pdft(
+    pdf_node: crate::parser::PdfNode,
+    images: &[String],
+    fonts: &[String],
+) -> crate::pdf_tree::PdfNode {
     let converter = PdfConverter::new();
-    converter.convert(pdf_node, images)
+    converter.convert(pdf_node, images, fonts)
 }
 
 #[cfg(test)]
@@ -48,15 +52,15 @@ mod tests {
     </pdf>
     ";
 
-    let node = crate::parser::parse(code).unwrap();
-    let pdft = to_pdft(node, &Vec::new());
+        let node = crate::parser::parse(code).unwrap();
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
 
-    let buffer = pdft.to_buffer();
-    let pdf_string = String::from_utf8_lossy(&buffer);
+        let buffer = pdft.to_buffer();
+        let pdf_string = String::from_utf8_lossy(&buffer);
 
-    assert_eq!(
-        pdf_string,
-        "%PDF-1.4
+        assert_eq!(
+            pdf_string,
+            "%PDF-1.4
 1 0 obj
 << /Type /Catalog
 /Pages 2 0 R
@@ -132,15 +136,15 @@ trailer
 >>
 startxref
 982
-%%EOF");
-
+%%EOF"
+        );
     }
 
     #[test]
     fn test_text_position_attributes() {
         let code = "<pdf><page><resource><font key=\"F1\" /></resource><content><text font=\"F1\" pos_x=\"20\" pos_y=\"50\">a</text></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("20 50 Td"));
@@ -150,7 +154,7 @@ startxref
     fn test_text_font_size_attribute() {
         let code = "<pdf><page><resource><font key=\"F1\" /></resource><content><text font_size=\"30\">a</text></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("/F1 30 Tf"));
@@ -160,7 +164,7 @@ startxref
     fn test_rectangle_generation() {
         let code = "<pdf><page><content><rectangle pos_x=\"10\" pos_y=\"20\" width=\"30\" height=\"40\" color=\"#FF0000\" /></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("10 20 cm"));
@@ -171,7 +175,7 @@ startxref
     fn test_rectangle_rotation() {
         let code = "<pdf><page><content><rectangle pos_x=\"10\" pos_y=\"20\" width=\"30\" height=\"40\" rotation=\"45\" /></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("0.707"));
@@ -181,7 +185,7 @@ startxref
     fn test_line_generation() {
         let code = "<pdf><page><content><line pos_x=\"5\" pos_y=\"15\" width=\"25\" color=\"#00FF00\" /></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("5 15 cm"));
@@ -191,7 +195,7 @@ startxref
     fn test_line_rotation() {
         let code = "<pdf><page><content><line pos_x=\"5\" pos_y=\"15\" width=\"25\" rotation=\"45\" /></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("0.707"));
@@ -201,7 +205,7 @@ startxref
     fn test_text_rotation() {
         let code = "<pdf><page><resource><font key=\"F1\" /></resource><content><text font=\"F1\" rotation=\"20\">a</text></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("0.939"));
@@ -211,7 +215,7 @@ startxref
     fn test_circle_generation() {
         let code = "<pdf><page><content><circle pos_x=\"10\" pos_y=\"20\" width=\"30\" height=\"40\" color=\"#FF0000\" /></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
-        let pdft = to_pdft(node, &Vec::new());
+        let pdft = to_pdft(node, &Vec::new(), &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("f"));
@@ -227,7 +231,7 @@ startxref
         let code = "<pdf><page><content><image src=\"pdfl_test_img.png\" /></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
         let images = vec![path.to_str().unwrap().to_string()];
-        let pdft = to_pdft(node, &images);
+        let pdft = to_pdft(node, &images, &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("/pdfl_test_img.png Do"));
@@ -245,12 +249,23 @@ startxref
         let code = "<pdf><page><content><image src=\"pdfl_test_img2.png\" rotation=\"20\" /></content></page></pdf>";
         let node = crate::parser::parse(code).unwrap();
         let images = vec![path.to_str().unwrap().to_string()];
-        let pdft = to_pdft(node, &images);
+        let pdft = to_pdft(node, &images, &Vec::new());
         let buffer = pdft.to_buffer();
         let pdf_string = String::from_utf8_lossy(&buffer);
         assert!(pdf_string.contains("pdfl_test_img2.png Do"));
         assert!(pdf_string.contains("17.10"));
 
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn test_external_font() {
+        let code = "<pdf><page><content><text font=\"matrix.ttf\">a</text></content></page></pdf>";
+        let node = crate::parser::parse(code).unwrap();
+        let fonts = vec!["docs/examples/matrix.ttf".to_string()];
+        let pdft = to_pdft(node, &Vec::new(), &fonts);
+        let buffer = pdft.to_buffer();
+        let pdf_string = String::from_utf8_lossy(&buffer);
+        assert!(pdf_string.contains("/FontFile2"));
     }
 }

--- a/src/ast2pdft/page_converter.rs
+++ b/src/ast2pdft/page_converter.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use crate::ast2pdft::content_converter::ContentConverter;
 use crate::ast2pdft::font_converter::FontConverter;
 use crate::ast2pdft::image_converter::ImageConverter;
-use crate::ast2pdft::content_converter::ContentConverter;
+use std::collections::HashMap;
 
 pub struct PageConverter;
 
@@ -16,6 +16,7 @@ impl PageConverter {
         obj_num: usize,
         gen_num: usize,
         images: &[String],
+        fonts_paths: &[String],
     ) -> (crate::pdf_tree::PageNode, usize) {
         let mut fonts = HashMap::new();
         let mut images_map = HashMap::new();
@@ -24,18 +25,31 @@ impl PageConverter {
         let font_converter = FontConverter::new();
         if let Some(res) = &ast_page.resources {
             for font in &res.fonts {
-                let (key, font_node) = font_converter.convert(font, next_obj, gen_num);
+                let (key, font_node, used) = font_converter.convert(font, next_obj, gen_num);
                 fonts.insert(key, font_node);
-                next_obj += 1;
+                next_obj += used;
             }
         } else {
-            fonts.insert("F1".to_string(), font_converter.create_default(next_obj, gen_num));
+            fonts.insert(
+                "F1".to_string(),
+                font_converter.create_default(next_obj, gen_num),
+            );
             next_obj += 1;
+        }
+
+        for font_path in fonts_paths {
+            let (name, font_node, used) =
+                font_converter.convert_file(font_path, next_obj, gen_num);
+            if !fonts.contains_key(&name) {
+                fonts.insert(name, font_node);
+                next_obj += used;
+            }
         }
 
         let image_converter = ImageConverter::new();
         for img_path in images {
-            let (name, image_xobject) = image_converter.convert_xobject(img_path, next_obj, gen_num);
+            let (name, image_xobject) =
+                image_converter.convert_xobject(img_path, next_obj, gen_num);
             images_map.insert(name, image_xobject);
             next_obj += 1;
         }

--- a/src/ast2pdft/pages_converter.rs
+++ b/src/ast2pdft/pages_converter.rs
@@ -7,7 +7,12 @@ impl PagesConverter {
         Self
     }
 
-    pub fn convert(&self, ast_page: crate::parser::PageNode, images: &[String]) -> (crate::pdf_tree::PagesNode, usize) {
+    pub fn convert(
+        &self,
+        ast_page: crate::parser::PageNode,
+        images: &[String],
+        fonts: &[String],
+    ) -> (crate::pdf_tree::PagesNode, usize) {
         let mut total_obj = 0;
         let mut kids: Vec<crate::pdf_tree::PageNode> = Vec::new();
         let mut obj_num = 3;
@@ -16,7 +21,8 @@ impl PagesConverter {
         let page_converter = PageConverter::new();
 
         loop {
-            let (page_node, used_obj) = page_converter.convert(&current_page, obj_num, 0, images);
+            let (page_node, used_obj) =
+                page_converter.convert(&current_page, obj_num, 0, images, fonts);
             total_obj += used_obj;
             obj_num += used_obj;
 

--- a/src/ast2pdft/pdf_converter_main.rs
+++ b/src/ast2pdft/pdf_converter_main.rs
@@ -11,9 +11,14 @@ impl PdfConverter {
         }
     }
 
-    pub fn convert(&self, pdf_node: crate::parser::PdfNode, images: &[String]) -> crate::pdf_tree::PdfNode {
+    pub fn convert(
+        &self,
+        pdf_node: crate::parser::PdfNode,
+        images: &[String],
+        fonts: &[String],
+    ) -> crate::pdf_tree::PdfNode {
         let catalog_converter = CatalogConverter::new();
-        let (catalog, total_obj) = catalog_converter.convert(pdf_node, images);
+        let (catalog, total_obj) = catalog_converter.convert(pdf_node, images, fonts);
 
         crate::pdf_tree::PdfNode {
             version: self.version.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ mod pdf_tree;
 #[wasm_bindgen]
 pub fn compile_pdfl(input: &str) -> Result<Box<[u8]>, JsValue> {
     let ast = parser::parse(input).map_err(|e| JsValue::from_str(&e))?;
-    let pdft = ast2pdft::to_pdft(ast, &Vec::new());
+    let pdft = ast2pdft::to_pdft(ast, &Vec::new(), &Vec::new());
     Ok(pdft.to_buffer().into_boxed_slice())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ struct Args {
     /// Image paths (can be specified multiple times)
     #[arg(short, long = "image", action = clap::ArgAction::Append)]
     images: Vec<String>,
+
+    /// Font paths (can be specified multiple times)
+    #[arg(short, long = "font", action = clap::ArgAction::Append)]
+    fonts: Vec<String>,
 }
 
 fn main() {
@@ -29,7 +33,7 @@ fn main() {
 
     let ast = parser::parse(&code).unwrap();
 
-    let pdft = ast2pdft::to_pdft(ast, &args.images);
+    let pdft = ast2pdft::to_pdft(ast, &args.images, &args.fonts);
 
     let node = pdft.to_buffer();
 

--- a/src/pdf_tree/font_descriptor_node.rs
+++ b/src/pdf_tree/font_descriptor_node.rs
@@ -1,0 +1,20 @@
+pub struct FontDescriptorNode {
+    pub obj_num: usize,
+    pub gen_num: usize,
+    pub font_name: String,
+    pub file_obj_num: usize,
+}
+
+impl FontDescriptorNode {
+    pub fn to_buffer(&self) -> Vec<u8> {
+        format!(
+            "{} {} obj\n<< /Type /FontDescriptor\n/FontName /{}\n/Flags 0\n/FontBBox [0 0 0 0]\n/ItalicAngle 0\n/Ascent 0\n/Descent 0\n/CapHeight 0\n/StemV 0\n/FontFile2 {} {} R\n>>\nendobj\n",
+            self.obj_num,
+            self.gen_num,
+            self.font_name,
+            self.file_obj_num,
+            self.gen_num
+        )
+        .into_bytes()
+    }
+}

--- a/src/pdf_tree/font_node.rs
+++ b/src/pdf_tree/font_node.rs
@@ -3,21 +3,64 @@ pub struct FontNode {
     pub gen_num: usize,
     pub subtype: String,
     pub base_font: String,
+    pub descriptor_obj_num: Option<usize>,
+    pub file_obj_num: Option<usize>,
+    pub data: Option<Vec<u8>>,
+    pub length1: Option<usize>,
 }
 
 impl FontNode {
-    pub fn to_buffer(&self) -> Vec<u8> {
-        let mut buffer = Vec::new();
+    pub fn obj_bytes(&self) -> Vec<u8> {
+        self.to_obj().into_bytes()
+    }
 
-        buffer.extend(self.to_obj().as_bytes());
+    pub fn descriptor_bytes(&self) -> Option<Vec<u8>> {
+        if let (Some(desc_obj), Some(file_obj)) = (self.descriptor_obj_num, self.file_obj_num) {
+            let desc = crate::pdf_tree::FontDescriptorNode {
+                obj_num: desc_obj,
+                gen_num: self.gen_num,
+                font_name: self.base_font.clone(),
+                file_obj_num: file_obj,
+            };
+            Some(desc.to_buffer())
+        } else {
+            None
+        }
+    }
 
-        return buffer;
+    pub fn file_bytes(&self) -> Option<Vec<u8>> {
+        if let (Some(obj_num), Some(data), Some(len1)) =
+            (self.file_obj_num, &self.data, self.length1)
+        {
+            let mut buf = Vec::new();
+            buf.extend(
+                format!(
+                    "{} {} obj\n<< /Length {} /Length1 {} /Filter /FlateDecode>>\nstream\n",
+                    obj_num,
+                    self.gen_num,
+                    data.len(),
+                    len1
+                )
+                .as_bytes(),
+            );
+            buf.extend(data);
+            buf.extend(b"\nendstream\nendobj\n");
+            Some(buf)
+        } else {
+            None
+        }
     }
 
     fn to_obj(&self) -> String {
-        return format!(
-            "{} {} obj\n<< /Type /Font\n/Subtype /{}\n/BaseFont /{}\n>>\nendobj\n",
-            self.obj_num, self.gen_num, self.subtype, self.base_font
-        );
+        match (self.descriptor_obj_num, self.file_obj_num) {
+            (Some(desc_obj), Some(_)) => format!(
+                "{} {} obj\n<< /Type /Font\n/Subtype /{}\n/BaseFont /{}\n/FontDescriptor {} {} R\n>>\nendobj\n",
+                self.obj_num, self.gen_num, self.subtype, self.base_font, desc_obj, self.gen_num
+            ),
+            _ => format!(
+                "{} {} obj\n<< /Type /Font\n/Subtype /{}\n/BaseFont /{}\n>>\nendobj\n",
+                self.obj_num, self.gen_num, self.subtype, self.base_font
+            ),
+        }
     }
 }

--- a/src/pdf_tree/mod.rs
+++ b/src/pdf_tree/mod.rs
@@ -1,5 +1,6 @@
 mod pdf_node;
 mod font_node;
+mod font_descriptor_node;
 mod page_node;
 mod pages_node;
 mod catalog_node;
@@ -13,6 +14,7 @@ mod image_xobject_node;
 
 pub use pdf_node::PdfNode;
 pub use font_node::FontNode;
+pub use font_descriptor_node::FontDescriptorNode;
 pub use page_node::PageNode;
 pub use pages_node::PagesNode;
 pub use catalog_node::CatalogNode;
@@ -36,6 +38,10 @@ mod tests {
             gen_num: 0,
             subtype: "Type1".to_string(),
             base_font: "Helvetica".to_string(),
+            descriptor_obj_num: None,
+            file_obj_num: None,
+            data: None,
+            length1: None,
         };
 
         let mut fonts = std::collections::HashMap::new();

--- a/src/pdf_tree/page_node.rs
+++ b/src/pdf_tree/page_node.rs
@@ -19,7 +19,15 @@ impl PageNode {
 
         for font in self.fonts.values() {
             xref.push(xref.last().unwrap() + buffer.len() + 1);
-            buffer.extend(font.to_buffer());
+            buffer.extend(font.obj_bytes());
+            if let Some(bytes) = font.descriptor_bytes() {
+                xref.push(xref.last().unwrap() + buffer.len() + 1);
+                buffer.extend(bytes);
+            }
+            if let Some(bytes) = font.file_bytes() {
+                xref.push(xref.last().unwrap() + buffer.len() + 1);
+                buffer.extend(bytes);
+            }
         }
 
         for image in self.images.values() {
@@ -34,11 +42,15 @@ impl PageNode {
     }
 
     fn to_obj(&self) -> String {
-        let fonts_str: Vec<String> = self.fonts.iter()
+        let fonts_str: Vec<String> = self
+            .fonts
+            .iter()
             .map(|(key, font)| format!("/{} {} {} R", key, font.obj_num, font.gen_num))
             .collect();
 
-        let images_str: Vec<String> = self.images.iter()
+        let images_str: Vec<String> = self
+            .images
+            .iter()
             .map(|(key, img)| format!("/{} {} {} R", key, img.obj_num, img.gen_num))
             .collect();
 


### PR DESCRIPTION
## Summary
- support fonts from external `.ttf` files
- create `FontDescriptorNode` with `/FontFile2` stream
- attach a font descriptor when embedding fonts
- update page object to write descriptor and font file objects

## Testing
- `cargo test --color=never`

------
https://chatgpt.com/codex/tasks/task_e_6876e3a45bcc8328b75b3211c145822f